### PR TITLE
Feature: mesh file import

### DIFF
--- a/rviz_map_plugin/CMakeLists.txt
+++ b/rviz_map_plugin/CMakeLists.txt
@@ -17,6 +17,14 @@ find_package(Boost REQUIRED COMPONENTS system)
 find_package(HDF5 REQUIRED COMPONENTS C CXX HL)
 find_package(OpenCL 2 REQUIRED)
 
+find_package(assimp)
+
+if(assimp_FOUND)
+  include_directories(${ASSIMP_INCLUDE_DIRS})
+  add_definitions(-DWITH_ASSIMP)
+endif(assimp_FOUND)
+
+
 catkin_package(
   CATKIN_DEPENDS ${THIS_PACKAGE_ROS_DEPS}
   DEPENDS Boost OpenCL HDF5 OpenCL

--- a/rviz_map_plugin/include/MapDisplay.hpp
+++ b/rviz_map_plugin/include/MapDisplay.hpp
@@ -67,6 +67,7 @@
 #include <QMessageBox>
 #include <QApplication>
 #include <QIcon>
+#include <QString>
 
 #include <ros/ros.h>
 #include <ros/console.h>
@@ -78,6 +79,7 @@
 #include <rviz/display_context.h>
 #include <rviz/frame_manager.h>
 #include <rviz/display.h>
+#include <rviz/config.h>
 
 #include <rviz/tool.h>
 #include <rviz/tool_manager.h>
@@ -149,6 +151,8 @@ public:
    */
   ~MapDisplay();
 
+  virtual void load(const rviz::Config& config);
+
 public Q_SLOTS:
 
   /**
@@ -210,8 +214,12 @@ private:
 
   std::map<std::string, std::vector<float>> m_costs;
 
+  std::shared_ptr<ros::NodeHandle> m_nh;
+  std::shared_ptr<ros::NodeHandle> m_nh_p;
+
   /// Path to map file
   rviz::FileProperty* m_mapFilePath;
+  std::string m_map_file_loaded;
 
   /// Subdisplay: ClusterLabel (for showing the clusters)
   rviz_map_plugin::ClusterLabelDisplay* m_clusterLabelDisplay;

--- a/rviz_map_plugin/src/MapDisplay.cpp
+++ b/rviz_map_plugin/src/MapDisplay.cpp
@@ -346,7 +346,12 @@ bool MapDisplay::loadData()
       // 
       Assimp::Importer io;
       io.SetPropertyBool(AI_CONFIG_IMPORT_COLLADA_IGNORE_UP_DIRECTION, true);
-      const aiScene* ascene = io.ReadFile(mapFile, 0);
+      
+      // with aiProcess_PreTransformVertices assimp transforms the whole scene graph
+      // into one mesh
+      // - if you want to use TF for spawning meshes, the loading has to be done manually
+      const aiScene* ascene = io.ReadFile(mapFile, aiProcess_PreTransformVertices);
+      // what if there is more than one mesh?
       const aiMesh* amesh = ascene->mMeshes[0];
 
       const aiVector3D* ai_vertices = amesh->mVertices;

--- a/rviz_map_plugin/src/MeshDisplay.cpp
+++ b/rviz_map_plugin/src/MeshDisplay.cpp
@@ -77,7 +77,7 @@ MeshDisplay::MeshDisplay() : rviz::Display(), m_ignoreMsgs(false)
       "Geometry topic to subscribe to.", this, SLOT(updateTopic()));
 
   // buffer size / amount of meshes visualized
-  m_bufferSize = new rviz::IntProperty("Buffer Size", 1, "Amount of meshes visualized", this, SLOT(updateBufferSize()));
+  m_bufferSize = new rviz::IntProperty("Buffer Size", 1, "Number of meshes visualized", this, SLOT(updateBufferSize()));
   m_bufferSize->setMin(1);
 
   // Display Type

--- a/rviz_map_plugin/src/RvizFileProperty.cpp
+++ b/rviz_map_plugin/src/RvizFileProperty.cpp
@@ -63,6 +63,16 @@ QWidget* FileProperty::createEditor(QWidget* parent, const QStyleOptionViewItem&
 
   QStringList filenameFilters;
   filenameFilters << tr("*.h5");
+  #if defined(WITH_ASSIMP)
+  filenameFilters << tr("*.ply");
+  filenameFilters << tr("*.obj");
+  filenameFilters << tr("*.dae");
+  filenameFilters << tr("*.stl");
+  filenameFilters << tr("*.3d");
+  filenameFilters << tr("*.3ds");
+  filenameFilters << tr("*.fbx");
+  filenameFilters << tr("*.blend");
+  #endif
   filenameFilters << tr("*");
   editor->setNameFilters(filenameFilters);
 


### PR DESCRIPTION
As soon as [Assimp](https://github.com/assimp/assimp) is installed on the system, it becomes possible to load other common mesh formats besides h5. [Assimp](https://github.com/assimp/assimp) can be installed by

```console
sudo apt-get install libassimp-dev
```

The complete change is optional. rviz_map_plugin should work without installing Assimp. If you want to have Assimp as a required dependency, change

```cmake
find_package(assimp)
```

to

```cmake
find_package(assimp REQUIRED)
```