### PR TITLE
Build in Ubuntu 23.04

### DIFF
--- a/rviz_map_plugin/include/ClusterLabelTool.hpp
+++ b/rviz_map_plugin/include/ClusterLabelTool.hpp
@@ -88,6 +88,7 @@
 #ifndef Q_MOC_RUN
 #include <rviz/mesh_loader.h>
 
+#include <OGRE/Ogre.h>
 #include <OGRE/OgreManualObject.h>
 #include <OGRE/OgreSceneNode.h>
 #include <OGRE/OgreSceneManager.h>
@@ -104,13 +105,6 @@ namespace rviz
 class RosTopicProperty;
 class ColorProperty;
 }  // namespace rviz
-
-// OGRE stuff
-namespace Ogre
-{
-// Forward declaration
-class Vector3;
-}  // namespace Ogre
 
 namespace rviz_map_plugin
 {

--- a/rviz_map_plugin/include/ClusterLabelVisual.hpp
+++ b/rviz_map_plugin/include/ClusterLabelVisual.hpp
@@ -64,13 +64,6 @@
 #include <memory>
 #include <vector>
 
-namespace Ogre
-{
-// Forward declaration
-class SceneNode;
-class Mesh;
-}  // End namespace Ogre
-
 namespace rviz_map_plugin
 {
 /**

--- a/rviz_map_plugin/include/MeshVisual.hpp
+++ b/rviz_map_plugin/include/MeshVisual.hpp
@@ -69,6 +69,7 @@
 #include <rviz/display_context.h>
 #include <rviz/frame_manager.h>
 
+#include <OGRE/Ogre.h>
 #include <OGRE/OgreSceneNode.h>
 #include <OGRE/OgreSceneManager.h>
 #include <OGRE/OgreManualObject.h>
@@ -78,16 +79,6 @@
 
 #include <Types.hpp>
 #include <vector>
-
-namespace Ogre
-{
-// Forward declaration
-class Vector3;
-class Quaternion;
-class SceneNode;
-class Entity;
-
-}  // End namespace Ogre
 
 namespace rviz_map_plugin
 {

--- a/rviz_map_plugin/src/ClusterLabelDisplay.cpp
+++ b/rviz_map_plugin/src/ClusterLabelDisplay.cpp
@@ -351,5 +351,5 @@ void ClusterLabelDisplay::addLabel(std::string label, std::vector<uint32_t> face
 
 }  // End namespace rviz_map_plugin
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS(rviz_map_plugin::ClusterLabelDisplay, rviz::Display)

--- a/rviz_map_plugin/src/ClusterLabelPanel.cpp
+++ b/rviz_map_plugin/src/ClusterLabelPanel.cpp
@@ -152,5 +152,5 @@ void ClusterLabelPanel::load(const rviz::Config& config)
 
 }  // End namespace rviz_map_plugin
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS(rviz_map_plugin::ClusterLabelPanel, rviz::Panel)

--- a/rviz_map_plugin/src/ClusterLabelTool.cpp
+++ b/rviz_map_plugin/src/ClusterLabelTool.cpp
@@ -61,7 +61,7 @@
 
 #include <OGRE/OgreColourValue.h>
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS(rviz_map_plugin::ClusterLabelTool, rviz::Tool)
 
 using std::ifstream;

--- a/rviz_map_plugin/src/ClusterLabelVisual.cpp
+++ b/rviz_map_plugin/src/ClusterLabelVisual.cpp
@@ -49,6 +49,7 @@
 
 #include <rviz/display_context.h>
 
+#include <OGRE/Ogre.h>
 #include <OGRE/OgreEntity.h>
 #include <OGRE/OgreMaterialManager.h>
 #include <OGRE/OgreMesh.h>

--- a/rviz_map_plugin/src/MapDisplay.cpp
+++ b/rviz_map_plugin/src/MapDisplay.cpp
@@ -386,5 +386,5 @@ void MapDisplay::saveLabel(Cluster cluster)
 
 }  // End namespace rviz_map_plugin
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS(rviz_map_plugin::MapDisplay, rviz::Display)

--- a/rviz_map_plugin/src/MeshDisplay.cpp
+++ b/rviz_map_plugin/src/MeshDisplay.cpp
@@ -991,5 +991,5 @@ std::shared_ptr<MeshVisual> MeshDisplay::addNewVisual()
 
 }  // End namespace rviz_map_plugin
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS(rviz_map_plugin::MeshDisplay, rviz::Display)

--- a/rviz_map_plugin/src/MeshDisplay.cpp
+++ b/rviz_map_plugin/src/MeshDisplay.cpp
@@ -282,13 +282,13 @@ void MeshDisplay::subscribe()
   else
   {
     m_meshSynchronizer = new message_filters::Cache<mesh_msgs::MeshGeometryStamped>(m_meshSubscriber, 10);
-    m_meshSynchronizer->registerCallback(boost::bind(&MeshDisplay::incomingGeometry, this, _1));
+    m_meshSynchronizer->registerCallback(boost::bind(&MeshDisplay::incomingGeometry, this, boost::placeholders::_1));
 
     m_colorsSynchronizer = new message_filters::Cache<mesh_msgs::MeshVertexColorsStamped>(m_vertexColorsSubscriber, 1);
-    m_colorsSynchronizer->registerCallback(boost::bind(&MeshDisplay::incomingVertexColors, this, _1));
+    m_colorsSynchronizer->registerCallback(boost::bind(&MeshDisplay::incomingVertexColors, this, boost::placeholders::_1));
 
     m_costsSynchronizer = new message_filters::Cache<mesh_msgs::MeshVertexCostsStamped>(m_vertexCostsSubscriber, 1);
-    m_costsSynchronizer->registerCallback(boost::bind(&MeshDisplay::incomingVertexCosts, this, _1));
+    m_costsSynchronizer->registerCallback(boost::bind(&MeshDisplay::incomingVertexCosts, this, boost::placeholders::_1));
   }
 
   initialServiceCall();
@@ -599,7 +599,7 @@ void MeshDisplay::updateVertexColorsTopic()
 
   m_vertexColorsSubscriber.subscribe(update_nh_, m_vertexColorsTopic->getTopicStd(), 1);
   m_colorsSynchronizer = new message_filters::Cache<mesh_msgs::MeshVertexColorsStamped>(m_vertexColorsSubscriber, 1);
-  m_colorsSynchronizer->registerCallback(boost::bind(&MeshDisplay::incomingVertexColors, this, _1));
+  m_colorsSynchronizer->registerCallback(boost::bind(&MeshDisplay::incomingVertexColors, this, boost::placeholders::_1));
 }
 
 void MeshDisplay::updateVertexCostsTopic()
@@ -609,7 +609,7 @@ void MeshDisplay::updateVertexCostsTopic()
 
   m_vertexCostsSubscriber.subscribe(update_nh_, m_vertexCostsTopic->getTopicStd(), 4);
   m_costsSynchronizer = new message_filters::Cache<mesh_msgs::MeshVertexCostsStamped>(m_vertexCostsSubscriber, 1);
-  m_costsSynchronizer->registerCallback(boost::bind(&MeshDisplay::incomingVertexCosts, this, _1));
+  m_costsSynchronizer->registerCallback(boost::bind(&MeshDisplay::incomingVertexCosts, this, boost::placeholders::_1));
 }
 
 void MeshDisplay::updateTopic()

--- a/rviz_map_plugin/src/MeshGoalTool.cpp
+++ b/rviz_map_plugin/src/MeshGoalTool.cpp
@@ -45,7 +45,7 @@
 
 #include "MeshGoalTool.hpp"
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS( rviz_map_plugin::MeshGoalTool, rviz::Tool )
 
 namespace rviz_map_plugin{


### PR DESCRIPTION
Got this building on Ubuntu 23.04 with these changes along with https://github.com/uos/lvr2/pull/15

The include Ogre.h may work on earlier Ogre versions, `class_list_macros.hpp` definitely works for several older versions of ros.

I could likely get rid of all the deprecation warnings but only went after errors here.