### PR TITLE
fix rosdep install on humble

### DIFF
--- a/.github/workflows/melodic.yml
+++ b/.github/workflows/melodic.yml
@@ -1,6 +1,12 @@
 name: Melodic CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - "humble**"
+  pull_request:
+    branches-ignore:
+      - "humble**"
 
 jobs:
   industrial_ci:

--- a/.github/workflows/noetic.yml
+++ b/.github/workflows/noetic.yml
@@ -1,6 +1,12 @@
 name: Noetic CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - "humble**"
+  pull_request:
+    branches-ignore:
+      - "humble**"
 
 jobs:
   industrial_ci:

--- a/rviz_mesh_tools_plugins/package.xml
+++ b/rviz_mesh_tools_plugins/package.xml
@@ -11,7 +11,6 @@
   <author email="krschmidt@uos.de">Kristin Schmidt</author>
   <author email="jvogtherr@uos.de">Jan Philipp Vogtherr</author>
   <author email="malte@klpiening.de">Malte kleine Piening</author>
-  <buildtool_depend>catkin</buildtool_depend>
 
   <license>BSD-3</license>
   <url>https://github.com/uos/mesh_tools/tree/master/rviz_mesh_tools_plugins</url>


### PR DESCRIPTION
Tiny PR that fixes an obsolete dependency to catkin and disables CI for all branches that start with humble.

Having catkin in there causes issues when running `rosdep install` with humble distro as a target. catkin is not available in humble.

CI will fail, since it only supports ROS1 for now.