### PR TITLE
Change QoS for meshes in RViz display

### DIFF
--- a/rviz_mesh_tools_plugins/include/rviz_mesh_tools_plugins/MeshDisplay.hpp
+++ b/rviz_mesh_tools_plugins/include/rviz_mesh_tools_plugins/MeshDisplay.hpp
@@ -404,9 +404,10 @@ private:
 
   // ================= UI members =================
 
-  /// Property to handle topic for meshMsg
+  /// Properties to handle topic for meshMsg
   rviz_common::properties::RosTopicProperty* m_meshTopic;
   rviz_common::properties::QosProfileProperty* m_meshTopicQos;
+  rclcpp::QoS m_meshQos;
 
   /// Property to handle buffer size
   rviz_common::properties::IntProperty* m_bufferSize;
@@ -420,8 +421,10 @@ private:
   /// Property to set faces transparency
   rviz_common::properties::FloatProperty* m_facesAlpha;
 
-  /// Property to handle topic for vertex colors
+  /// Properties to handle topic for vertex colors
   rviz_common::properties::RosTopicProperty* m_vertexColorsTopic;
+  rviz_common::properties::QosProfileProperty* m_vertexColorsTopicQos;
+  rclcpp::QoS m_vertexColorsQos;
 
   /// Property to handle service name for vertexColors
   rviz_common::properties::StringProperty* m_vertexColorServiceName;
@@ -438,8 +441,10 @@ private:
   /// Property for selecting the color type for cost display
   rviz_common::properties::EnumProperty* m_costColorType;
 
-  /// Property to handle topic for vertex cost maps
+  /// Properties to handle topic for vertex cost maps
   rviz_common::properties::RosTopicProperty* m_vertexCostsTopic;
+  rviz_common::properties::QosProfileProperty* m_vertexCostsTopicQos;
+  rclcpp::QoS m_vertexCostsQos;
 
   /// Property to select different types of vertex cost maps to be shown
   rviz_common::properties::EnumProperty* m_selectVertexCostMap;
@@ -476,9 +481,6 @@ private:
 
   /// Cache for received vertex cost messages
   std::map<std::string, std::vector<float>> m_costCache;
-
-  // const rmw_qos_profile_t m_qos;
-  rclcpp::QoS m_qos;
 };
 
 }  // end namespace rviz_mesh_tools_plugins

--- a/rviz_mesh_tools_plugins/include/rviz_mesh_tools_plugins/MeshDisplay.hpp
+++ b/rviz_mesh_tools_plugins/include/rviz_mesh_tools_plugins/MeshDisplay.hpp
@@ -115,6 +115,7 @@ class ColorProperty;
 class FloatProperty;
 class IntProperty;
 class RosTopicProperty;
+class QosProfileProperty;
 class EnumProperty;
 class StringProperty;
 } // end namespace properties
@@ -405,6 +406,7 @@ private:
 
   /// Property to handle topic for meshMsg
   rviz_common::properties::RosTopicProperty* m_meshTopic;
+  rviz_common::properties::QosProfileProperty* m_meshTopicQos;
 
   /// Property to handle buffer size
   rviz_common::properties::IntProperty* m_bufferSize;
@@ -475,7 +477,8 @@ private:
   /// Cache for received vertex cost messages
   std::map<std::string, std::vector<float>> m_costCache;
 
-  const rmw_qos_profile_t m_qos;
+  // const rmw_qos_profile_t m_qos;
+  rclcpp::QoS m_qos;
 };
 
 }  // end namespace rviz_mesh_tools_plugins


### PR DESCRIPTION
This is a follow-up of PR #34 . It was not able to visualize a mesh geometry from topic because my publisher had not the same QoS configuration than the RViz plugin's subscriber. To fix this, I added an option to change the QoS in Rviz. The configuration of PR #34 remains the default.

I tested it with the code of this repo: https://github.com/aock/mesh_msgs_examples 