### PR TITLE
Post lvr2 update

### DIFF
--- a/source_dependencies.yaml
+++ b/source_dependencies.yaml
@@ -4,4 +4,4 @@ repositories:
   uos/lvr2:
     type: git
     url: https://github.com/uos/lvr2.git
-    version: version-upgrade
+    version: main


### PR DESCRIPTION
As the upgrade of lvr2 is finalized now, we can switch the source dependency to the main branch.