### PR TITLE
removed actionlib_msgs

### DIFF
--- a/label_manager/CMakeLists.txt
+++ b/label_manager/CMakeLists.txt
@@ -18,7 +18,6 @@ find_package(rclcpp REQUIRED)
 find_package(rclcpp_action REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
-find_package(actionlib_msgs REQUIRED)
 find_package(mesh_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
@@ -61,7 +60,6 @@ ament_target_dependencies(${PROJECT_NAME}_node
   rclcpp
   rclcpp_action
   rclcpp_components
-  actionlib_msgs
   mesh_msgs
   sensor_msgs
   std_msgs

--- a/label_manager/package.xml
+++ b/label_manager/package.xml
@@ -21,7 +21,6 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_action</depend>
   <depend>rclcpp_components</depend>
-  <depend>actionlib_msgs</depend>
   <depend>mesh_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>


### PR DESCRIPTION
removed `actionlib_msgs`, as they are not used anywhere. Also from jazzy on using the `actionlib_msgs` package will cause a deprecation warning:

```console
CMake Deprecation Warning at /opt/ros/jazzy/share/actionlib_msgs/cmake/actionlib_msgsConfig.cmake:31 (message):
  Package 'actionlib_msgs' is deprecated (This package will be removed in a
  future ROS distro, once the ROS 1 bridge supports actions.)
```