### PR TITLE
Hardware culling support for meshes

### DIFF
--- a/rviz_mesh_tools_plugins/include/rviz_mesh_tools_plugins/MeshDisplay.hpp
+++ b/rviz_mesh_tools_plugins/include/rviz_mesh_tools_plugins/MeshDisplay.hpp
@@ -312,6 +312,11 @@ private Q_SLOTS:
    */
   void updateMaterialAndTextureServices();
 
+  /**
+   * @brief Updates the hardware culling mode of the mesh
+   */
+  void updateCullingMode();
+
 private:
   /**
    * @brief RViz callback on initialize
@@ -497,6 +502,9 @@ private:
 
   /// Property to set wireframe transparency
   rviz_common::properties::FloatProperty* m_wireframeAlpha;
+
+  /// Property to select the hardware culling mode
+  rviz_common::properties::EnumProperty* m_cullingMode;
 
   /// Cache for received vertex cost messages
   std::map<std::string, std::vector<float>> m_costCache;

--- a/rviz_mesh_tools_plugins/include/rviz_mesh_tools_plugins/MeshVisual.hpp
+++ b/rviz_mesh_tools_plugins/include/rviz_mesh_tools_plugins/MeshVisual.hpp
@@ -197,6 +197,13 @@ public:
   void setFrameOrientation(const Ogre::Quaternion& orientation);
 
   /**
+   * @brief Sets the hardware culling mode of the mesh.
+   *
+   * @param mode The hardware culling mode
+   */
+  void setCullingMode(Ogre::CullingMode mode);
+
+  /**
    * @brief Updates the visible parts of the mesh depending on input from the rviz display.
    *
    * @param showFaces             When TRUE faces are visible
@@ -381,6 +388,9 @@ private:
 
   /// Factor the normal-size is multiplied with.
   float m_normalsScalingFactor;
+
+  /// Hardware culling mode
+  Ogre::CullingMode m_cullingMode;
 
   /// raw Triangle Mesh
   Geometry m_geometry;

--- a/rviz_mesh_tools_plugins/src/MeshDisplay.cpp
+++ b/rviz_mesh_tools_plugins/src/MeshDisplay.cpp
@@ -235,6 +235,15 @@ MeshDisplay::MeshDisplay()
     m_scalingFactor = new rviz_common::properties::FloatProperty("Normals Scaling Factor", 0.1, "Scaling factor of the normals",
                                               m_showNormals, SLOT(updateNormalsSize()), this);
   }
+
+  // Culling
+  {
+    m_cullingMode = new rviz_common::properties::EnumProperty("Culling Mode (HW)", "None", "Select Hardware Culling Mode for Mesh", this,
+      SLOT(updateCullingMode()), this);
+    m_cullingMode->addOption("None", Ogre::CULL_NONE);
+    m_cullingMode->addOption("Clockwise", Ogre::CULL_CLOCKWISE);
+    m_cullingMode->addOption("Anticlockwise", Ogre::CULL_ANTICLOCKWISE);
+  }
 }
 
 MeshDisplay::~MeshDisplay()
@@ -358,7 +367,10 @@ void MeshDisplay::onDisable()
   }
 
   unsubscribe();
-  reset();
+  if (!m_ignoreMsgs)
+  {
+    reset();
+  }
 }
 
 void MeshDisplay::transformerChangedCallback()
@@ -468,6 +480,7 @@ void MeshDisplay::setGeometry(shared_ptr<Geometry> geometry)
     updateMeshMaterial();
     updateNormals();
     updateWireframe();
+    updateCullingMode();
   }
   setStatus(rviz_common::properties::StatusProperty::Ok, "Display", "");
 }
@@ -835,6 +848,15 @@ void MeshDisplay::updateVertexColorService()
   else
   {
     setStatus(rviz_common::properties::StatusProperty::Warn, "Services", QString("The specified Vertex Color Service doesn't exist."));
+  }
+}
+
+void MeshDisplay::updateCullingMode()
+{
+  std::shared_ptr<MeshVisual> visual = getLatestVisual();
+  if (visual)
+  {
+    visual->setCullingMode(static_cast<Ogre::CullingMode>(m_cullingMode->getOptionInt()));
   }
 }
 

--- a/rviz_mesh_tools_plugins/src/MeshVisual.cpp
+++ b/rviz_mesh_tools_plugins/src/MeshVisual.cpp
@@ -106,6 +106,7 @@ MeshVisual::MeshVisual(rviz_common::DisplayContext* context, size_t displayID, s
   , m_postfix(meshID)
   , m_random(randomID)
   , m_normalsScalingFactor(1)
+  , m_cullingMode(Ogre::CULL_NONE)
 {
   RCLCPP_INFO(rclcpp::get_logger("rviz_mesh_tools_plugins"), "Creating MeshVisual %lu_TexturedMesh_%lu_%lu", m_prefix, m_postfix, m_random);
 
@@ -411,7 +412,7 @@ void MeshVisual::showWireframe(Ogre::Pass* pass, Ogre::ColourValue wireframeColo
     pass->setDepthWriteEnabled(true);
   }
   pass->setPolygonMode(Ogre::PM_WIREFRAME);
-  pass->setCullingMode(Ogre::CULL_NONE);
+  pass->setCullingMode(m_cullingMode);
 }
 
 void MeshVisual::showFaces(Ogre::Pass* pass, Ogre::ColourValue facesColor, float facesAlpha,
@@ -431,7 +432,7 @@ void MeshVisual::showFaces(Ogre::Pass* pass, Ogre::ColourValue facesColor, float
     pass->setDepthWriteEnabled(false);
   }
   pass->setPolygonMode(Ogre::PM_SOLID);
-  pass->setCullingMode(Ogre::CULL_NONE);
+  pass->setCullingMode(m_cullingMode);
 }
 
 void MeshVisual::showNormals(Ogre::Pass* pass, Ogre::ColourValue normalsColor, float normalsAlpha)
@@ -444,7 +445,7 @@ void MeshVisual::showNormals(Ogre::Pass* pass, Ogre::ColourValue normalsColor, f
     pass->setDepthWriteEnabled(true);
   }
   pass->setPolygonMode(Ogre::PM_WIREFRAME);
-  pass->setCullingMode(Ogre::CULL_NONE);
+  pass->setCullingMode(m_cullingMode);
 }
 
 void MeshVisual::updateMaterial(
@@ -720,7 +721,7 @@ void MeshVisual::enteringTriangleMeshWithVertexCosts(const Geometry& mesh, const
         sstm.str(), Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME, true);
 
     Ogre::Pass* pass = m_vertexCostMaterial->getTechnique(0)->getPass(0);
-    pass->setCullingMode(Ogre::CULL_NONE);
+    pass->setCullingMode(m_cullingMode);
     pass->setLightingEnabled(false);
 
     // start entering data
@@ -771,7 +772,7 @@ void MeshVisual::enteringTexturedTriangleMesh(const Geometry& mesh, const vector
   m_noTexCluMesh->setVisible(false);
 
   Ogre::Pass* pass = m_noTexCluMaterial->getTechnique(0)->getPass(0);
-  pass->setCullingMode(Ogre::CULL_NONE);
+  pass->setCullingMode(m_cullingMode);
   pass->setLightingEnabled(false);
 
   m_noTexCluMesh->begin(m_noTexCluMaterial->getName(), Ogre::RenderOperation::OT_TRIANGLE_LIST);
@@ -794,7 +795,7 @@ void MeshVisual::enteringTexturedTriangleMesh(const Geometry& mesh, const vector
       // set some rendering options for textured clusters
       Ogre::Pass* pass = m_textureMaterials[textureIndex]->getTechnique(0)->getPass(0);
       // pass->setTextureFiltering(Ogre::TFO_NONE);
-      pass->setCullingMode(Ogre::CULL_NONE);
+      pass->setCullingMode(m_cullingMode);
       pass->setLightingEnabled(false);
 
       // check if image was already loaded
@@ -1181,6 +1182,40 @@ void MeshVisual::setFramePosition(const Ogre::Vector3& position)
 void MeshVisual::setFrameOrientation(const Ogre::Quaternion& orientation)
 {
   m_sceneNode->setOrientation(orientation);
+}
+
+void MeshVisual::setCullingMode(Ogre::CullingMode cullingMode)
+{
+  m_cullingMode = cullingMode;
+
+  if (m_meshGeneralMaterial)
+  {
+    m_meshGeneralMaterial->setCullingMode(cullingMode);
+  }
+  if (m_normalMaterial)
+  {
+    m_normalMaterial->setCullingMode(cullingMode);
+  }
+  if (m_vertexCostMaterial)
+  {
+    m_vertexCostMaterial->setCullingMode(cullingMode);
+  }
+  if (m_noTexCluMaterial)
+  {
+    m_noTexCluMaterial->setCullingMode(cullingMode);
+  }
+  if (m_texturedMeshMaterial)
+  {
+    m_texturedMeshMaterial->setCullingMode(cullingMode);
+  }
+  if (m_meshTexturedTrianglesMaterial)
+  {
+    m_meshTexturedTrianglesMaterial->setCullingMode(cullingMode);
+  }
+  for (auto& material : m_textureMaterials)
+  {
+    material->setCullingMode(cullingMode);
+  }
 }
 
 }  // end namespace rviz_mesh_tools_plugins


### PR DESCRIPTION
Meshes now support hardware culling for all display types and wireframe. It can be set to none, clockwise or anticlockwise.

Also hide/show meshes loaded from file is fixed.